### PR TITLE
fix: useless assignment to local variable [issue #227]

### DIFF
--- a/lib/utils/sanitize.js
+++ b/lib/utils/sanitize.js
@@ -30,11 +30,12 @@ function sanitize(data) {
 
   let lines = clean.split("\r\n");
 
-  lines.forEach((l) => {
-    if (l) {
-      l = l.trim();
+  lines.forEach((value, index) => {
+    if (value) {
+      lines[index] = value.trim();
     }
   });
+
 
   // remove empty lines, or null
   lines = lines.filter((value) => !(value === "" || value === null));


### PR DESCRIPTION
#227 

Since _l_ was scoped to the loop and its value wasn't reassigned to the lines array, any modifications made to _l_ inside the loop won't affect the original array.